### PR TITLE
ci: pin shivammathur/setup-php to 2.37.1

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@2.37.1
         with:
           php-version: 'latest'
           extensions: intl, mbstring, json


### PR DESCRIPTION
Pins `shivammathur/setup-php` to `2.37.1`, resolving **GHSA-5wxr-w449-57cm** as flagged by the [org SBOM scan](https://github.com/MahoCommerce/sboms).

Files changed: 1 workflow file(s).